### PR TITLE
Add PC Operations

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ func main() {
 	r := http.NewServeMux()
 
 	r.Handle("/pokemon/", &pkmn.PokemonHandler{})
-	r.Handle("/pc", &pc.PCHandler{
+	r.Handle("/pc/", &pc.PCHandler{
 		ActiveTeam: pc.PokemonTeam{
 			PokemonTeam: make([]pkmn.ActivePokemon, 0),
 		},

--- a/main.go
+++ b/main.go
@@ -15,10 +15,10 @@ func main() {
 	r.Handle("/pokemon/", &pkmn.PokemonHandler{})
 	r.Handle("/pc/", &pc.PCHandler{
 		ActiveTeam: pc.PokemonTeam{
-			PokemonTeam: make([]pkmn.ActivePokemon, 0),
+			PokemonTeam: make(map[string]pkmn.ActivePokemon),
 		},
 		PkmnBox: pc.PokemonStorageBox{
-			PCBox: make([]pkmn.ActivePokemon, 0),
+			PCBox: make(map[string]pkmn.ActivePokemon),
 		},
 	})
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 
+	pc "github.com/Lissless/poke-optimizer-api/pc_ops"
 	"github.com/Lissless/poke-optimizer-api/pkmn"
 	"github.com/rs/cors"
 )
@@ -12,6 +13,14 @@ func main() {
 	r := http.NewServeMux()
 
 	r.Handle("/pokemon/", &pkmn.PokemonHandler{})
+	r.Handle("/pc", &pc.PCHandler{
+		ActiveTeam: pc.PokemonTeam{
+			PokemonTeam: make([]pkmn.ActivePokemon, 0),
+		},
+		PkmnBox: pc.PokemonStorageBox{
+			PCBox: make([]pkmn.ActivePokemon, 0),
+		},
+	})
 
 	// Solves Cross Origin Access Issue
 	c := cors.New(cors.Options{

--- a/pc_ops/pc.go
+++ b/pc_ops/pc.go
@@ -1,0 +1,57 @@
+package pc
+
+import (
+	"log"
+
+	"github.com/Lissless/poke-optimizer-api/pkmn"
+)
+
+func MovePokemonFromTeamToBox(pkmnTeam PokemonTeam, pkmnBox PokemonStorageBox, pkmnUID string) (PokemonTeam, PokemonStorageBox, bool) {
+	pkmn, valid := pkmnTeam.RemovePokemon(pkmnUID)
+	if !valid {
+		return pkmnTeam, pkmnBox, false
+	}
+	// add pokemon to the box
+	pkmnBox.PCBox[pkmnUID] = pkmn
+	return pkmnTeam, pkmnBox, true
+}
+
+func MovePokemonFromBoxToTeam(pkmnTeam PokemonTeam, pkmnBox PokemonStorageBox, pkmnUID string) (PokemonTeam, PokemonStorageBox, bool) {
+	pkmn, valid := pkmnBox.RemovePokemon(pkmnUID)
+	if !valid {
+		return pkmnTeam, pkmnBox, false
+	}
+	if !EnforceTeamLimit(pkmnTeam) {
+		return pkmnTeam, pkmnBox, false
+	}
+	// add pokemon to the team
+	pkmnTeam.PokemonTeam[pkmnUID] = pkmn
+	return pkmnTeam, pkmnBox, true
+}
+
+func EnforceTeamLimit(pkmnTeam PokemonTeam) bool {
+	if len(pkmnTeam.PokemonTeam) == 6 {
+		// cannot have more than 6 pokemon in a team
+		log.Printf("Attempted to add more pokemon to a full team")
+		return false
+	}
+	return true
+}
+
+func (pt *PokemonTeam) RemovePokemon(PkmnUID string) (pkmn.ActivePokemon, bool) {
+	target := pt.PokemonTeam[PkmnUID]
+	if target.UID == "" {
+		return target, false
+	}
+	delete(pt.PokemonTeam, PkmnUID)
+	return target, true
+}
+
+func (pb *PokemonStorageBox) RemovePokemon(PkmnUID string) (pkmn.ActivePokemon, bool) {
+	target := pb.PCBox[PkmnUID]
+	if target.UID == "" {
+		return target, false
+	}
+	delete(pb.PCBox, PkmnUID)
+	return target, true
+}

--- a/pc_ops/pc.go
+++ b/pc_ops/pc.go
@@ -38,18 +38,34 @@ func EnforceTeamLimit(pkmnTeam PokemonTeam) bool {
 	return true
 }
 
-func (pt *PokemonTeam) RemovePokemon(PkmnUID string) (pkmn.ActivePokemon, bool) {
+func (pt *PokemonTeam) GetPokemon(PkmnUID string) (pkmn.ActivePokemon, bool) {
 	target := pt.PokemonTeam[PkmnUID]
 	if target.UID == "" {
+		return target, false
+	}
+	return target, true
+}
+
+func (pt *PokemonTeam) RemovePokemon(PkmnUID string) (pkmn.ActivePokemon, bool) {
+	target, valid := pt.GetPokemon(PkmnUID)
+	if !valid {
 		return target, false
 	}
 	delete(pt.PokemonTeam, PkmnUID)
 	return target, true
 }
 
-func (pb *PokemonStorageBox) RemovePokemon(PkmnUID string) (pkmn.ActivePokemon, bool) {
+func (pb *PokemonStorageBox) GetPokemon(PkmnUID string) (pkmn.ActivePokemon, bool) {
 	target := pb.PCBox[PkmnUID]
 	if target.UID == "" {
+		return target, false
+	}
+	return target, true
+}
+
+func (pb *PokemonStorageBox) RemovePokemon(PkmnUID string) (pkmn.ActivePokemon, bool) {
+	target, valid := pb.GetPokemon(PkmnUID)
+	if !valid {
 		return target, false
 	}
 	delete(pb.PCBox, PkmnUID)

--- a/pc_ops/pc_endpoints.go
+++ b/pc_ops/pc_endpoints.go
@@ -15,13 +15,25 @@ type PCHandler struct {
 	PkmnBox    PokemonStorageBox
 }
 
+const (
+	ACTIVE_TEAM_PATH = "/pc/team"
+	BOX_PATH         = "/pc/box"
+	TRANSFER_PATH    = "/pc/transfer"
+)
+
 func (pc *PCHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
-	case r.Method == http.MethodGet:
+	case r.Method == http.MethodGet && r.URL.Path == ACTIVE_TEAM_PATH:
 		pc.GetPokemonTeam(w, r)
 		return
-	case r.Method == http.MethodPut:
-		pc.AppendToPokemonTeam(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == BOX_PATH:
+		pc.GetPokemonBox(w, r)
+		return
+	case r.Method == http.MethodPut && r.URL.Path == ACTIVE_TEAM_PATH:
+		pc.AddPokemon(w, r, true)
+		return
+	case r.Method == http.MethodPut && r.URL.Path == BOX_PATH:
+		pc.AddPokemon(w, r, false)
 		return
 	default:
 		log.Printf("Invalid route was attempted route: %s", r.URL)
@@ -41,16 +53,28 @@ func (pc *PCHandler) GetPokemonTeam(w http.ResponseWriter, r *http.Request) {
 	w.Write(write_resp)
 }
 
-func (pc *PCHandler) AppendToPokemonTeam(w http.ResponseWriter, r *http.Request) {
-	if len(pc.ActiveTeam.PokemonTeam) == 6 {
+func (pc *PCHandler) GetPokemonBox(w http.ResponseWriter, r *http.Request) {
+	write_resp, err := json.Marshal(pc.PkmnBox)
+	if err != nil {
+		log.Printf("Marshalling the request to get the pokemon box failed, error: %s", err.Error())
+		pkmn_errors.ErrorHandler(w, r, http.StatusInternalServerError, "Failed packaging pokemon box request")
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(write_resp)
+}
+
+func (pc *PCHandler) AddPokemon(w http.ResponseWriter, r *http.Request, locTeam bool) {
+	if len(pc.ActiveTeam.PokemonTeam) == 6 && locTeam {
 		// cannot have more than 6 pokemon in a team
-		log.Printf("Attempted to add more pokrmon to a full team")
+		log.Printf("Attempted to add more pokemon to a full team")
 		pkmn_errors.ErrorHandler(w, r, http.StatusInternalServerError, "Failed: current team is too full")
 	}
 
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		log.Printf("Reading request body to GET the url: failed, error: %s", err.Error())
+		log.Printf("Append Pokemon Reading request body to GET the url: failed, error: %s", err.Error())
 		pkmn_errors.ErrorHandler(w, r, http.StatusInternalServerError, "Failed reading request body")
 		return
 	}
@@ -58,15 +82,35 @@ func (pc *PCHandler) AppendToPokemonTeam(w http.ResponseWriter, r *http.Request)
 
 	newPKMN := pkmn.ActivePokemon{}
 	err = json.Unmarshal(body, &newPKMN)
-	// change this later
 	if err != nil {
-		log.Printf("Reading request body to GET the url: failed, error: %s", err.Error())
-		pkmn_errors.ErrorHandler(w, r, http.StatusInternalServerError, "Failed reading request body")
+		log.Printf("Reading request body to GET the pokemon for adding to the team or storage: failed, error: %s", err.Error())
+		pkmn_errors.ErrorHandler(w, r, http.StatusInternalServerError, "Failed reading request body to add pokemon to team or storage")
 		return
 	}
 
+	err = newPKMN.GeneratePkmnUID()
+	if err != nil {
+		log.Printf("Failed generating UID for a pokemon, error: %s", err.Error())
+		pkmn_errors.ErrorHandler(w, r, http.StatusInternalServerError, "Failed assigning the pokemon an unique identifier")
+		return
+	}
+
+	var write_resp []byte
+	if locTeam {
 	pc.ActiveTeam.PokemonTeam = append(pc.ActiveTeam.PokemonTeam, newPKMN)
+		write_resp, err = json.Marshal(pc.ActiveTeam.PokemonTeam)
 
-	// Todo: return the new pc team immediately
+	} else {
+		pc.PkmnBox.PCBox = append(pc.PkmnBox.PCBox, newPKMN)
+		write_resp, err = json.Marshal(pc.PkmnBox.PCBox)
+	}
 
+	if err != nil {
+		log.Printf("Marshalling the request to GET the pokemon team or storage, error: %s", err.Error())
+		pkmn_errors.ErrorHandler(w, r, http.StatusInternalServerError, "Failed packaging pokemon team or storage request")
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(write_resp)
 }

--- a/pc_ops/pc_endpoints.go
+++ b/pc_ops/pc_endpoints.go
@@ -1,0 +1,72 @@
+package pc
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/Lissless/poke-optimizer-api/pkmn"
+	"github.com/Lissless/poke-optimizer-api/pkmn_errors"
+)
+
+type PCHandler struct {
+	ActiveTeam PokemonTeam
+	PkmnBox    PokemonStorageBox
+}
+
+func (pc *PCHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.Method == http.MethodGet:
+		pc.GetPokemonTeam(w, r)
+		return
+	case r.Method == http.MethodPut:
+		pc.AppendToPokemonTeam(w, r)
+		return
+	default:
+		log.Printf("Invalid route was attempted route: %s", r.URL)
+		pkmn_errors.ErrorHandler(w, r, http.StatusInternalServerError, "Invalid request")
+	}
+}
+
+func (pc *PCHandler) GetPokemonTeam(w http.ResponseWriter, r *http.Request) {
+	write_resp, err := json.Marshal(pc.ActiveTeam)
+	if err != nil {
+		log.Printf("Marshalling the request to get a pokemon team: failed, error: %s", err.Error())
+		pkmn_errors.ErrorHandler(w, r, http.StatusInternalServerError, "Failed packaging pokemon team request")
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(write_resp)
+}
+
+func (pc *PCHandler) AppendToPokemonTeam(w http.ResponseWriter, r *http.Request) {
+	if len(pc.ActiveTeam.PokemonTeam) == 6 {
+		// cannot have more than 6 pokemon in a team
+		log.Printf("Attempted to add more pokrmon to a full team")
+		pkmn_errors.ErrorHandler(w, r, http.StatusInternalServerError, "Failed: current team is too full")
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("Reading request body to GET the url: failed, error: %s", err.Error())
+		pkmn_errors.ErrorHandler(w, r, http.StatusInternalServerError, "Failed reading request body")
+		return
+	}
+	defer r.Body.Close()
+
+	newPKMN := pkmn.ActivePokemon{}
+	err = json.Unmarshal(body, &newPKMN)
+	// change this later
+	if err != nil {
+		log.Printf("Reading request body to GET the url: failed, error: %s", err.Error())
+		pkmn_errors.ErrorHandler(w, r, http.StatusInternalServerError, "Failed reading request body")
+		return
+	}
+
+	pc.ActiveTeam.PokemonTeam = append(pc.ActiveTeam.PokemonTeam, newPKMN)
+
+	// Todo: return the new pc team immediately
+
+}

--- a/pc_ops/pc_models.go
+++ b/pc_ops/pc_models.go
@@ -1,0 +1,14 @@
+package pc
+
+import "github.com/Lissless/poke-optimizer-api/pkmn"
+
+// Every user will have their own "active team" and their own
+// storage box, find a way to store this per person, mongo?
+
+type PokemonTeam struct {
+	PokemonTeam []pkmn.ActivePokemon `json:"pokemon_team"`
+}
+
+type PokemonStorageBox struct {
+	PCBox []pkmn.ActivePokemon `json:"pc_box_pokemon"`
+}

--- a/pc_ops/pc_models.go
+++ b/pc_ops/pc_models.go
@@ -13,7 +13,7 @@ type PokemonStorageBox struct {
 	PCBox map[string]pkmn.ActivePokemon `json:"pc_box_pokemon"`
 }
 
-type PokemonTransfer struct {
+type PokemonLocation struct {
 	Location   string `json:"location"`
 	PokemonUID string `json:"uid"`
 }

--- a/pc_ops/pc_models.go
+++ b/pc_ops/pc_models.go
@@ -6,9 +6,14 @@ import "github.com/Lissless/poke-optimizer-api/pkmn"
 // storage box, find a way to store this per person, mongo?
 
 type PokemonTeam struct {
-	PokemonTeam []pkmn.ActivePokemon `json:"pokemon_team"`
+	PokemonTeam map[string]pkmn.ActivePokemon `json:"pokemon_team"`
 }
 
 type PokemonStorageBox struct {
-	PCBox []pkmn.ActivePokemon `json:"pc_box_pokemon"`
+	PCBox map[string]pkmn.ActivePokemon `json:"pc_box_pokemon"`
+}
+
+type PokemonTransfer struct {
+	Location   string `json:"location"`
+	PokemonUID string `json:"uid"`
 }

--- a/pkmn/pokemon.go
+++ b/pkmn/pokemon.go
@@ -3,7 +3,7 @@ package pkmn
 func MakePokemon(dataMap map[string]interface{}, name string) Pokemon {
 	pkmn := Pokemon{
 		Name:      name,
-		ID:        dataMap["id"].(float64),
+		PokedexID: dataMap["id"].(float64),
 		Types:     makeTypesArray(dataMap["types"].([]interface{})),
 		Abilities: makeAbilitiesArray(dataMap["abilities"].([]interface{})),
 	}

--- a/pkmn/pokemon_endpoints.go
+++ b/pkmn/pokemon_endpoints.go
@@ -26,7 +26,7 @@ func (ph *PokemonHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	default:
 		log.Printf("Invalid route was attempted route: %s", r.URL)
-		pkmn_errors.ErrorHandler(w, r, http.StatusInternalServerError, "Invalid request")
+		pkmn_errors.ErrorHandler(w, r, http.StatusBadRequest, "Invalid request")
 	}
 }
 

--- a/pkmn/pokemon_endpoints.go
+++ b/pkmn/pokemon_endpoints.go
@@ -53,7 +53,12 @@ func (ph *PokemonHandler) GetPokemon(w http.ResponseWriter, r *http.Request) {
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("Reading request body to GET the url: %s failed, error: %s", getPokemonURL, err.Error())
+		pkmn_errors.ErrorHandler(w, r, http.StatusInternalServerError, "Failed reading request body")
+		return
+	}
 	dataMap := make(map[string]interface{})
 
 	err = json.Unmarshal(body, &dataMap)
@@ -68,7 +73,7 @@ func (ph *PokemonHandler) GetPokemon(w http.ResponseWriter, r *http.Request) {
 	write_resp, err := json.Marshal(pkmn)
 	if err != nil {
 		log.Printf("Marshalling the request to GET the url: %s failed, error: %s", getPokemonURL, err.Error())
-		pkmn_errors.ErrorHandler(w, r, http.StatusInternalServerError, "Failed packaging request")
+		pkmn_errors.ErrorHandler(w, r, http.StatusInternalServerError, "Failed packaging pokemon request")
 		return
 	}
 

--- a/pkmn/pokemon_models.go
+++ b/pkmn/pokemon_models.go
@@ -9,6 +9,13 @@ type Pokemon struct {
 	Abilities []PokemonAbility `json:"abilities"`
 }
 
+type ActivePokemon struct {
+	Name      string         `json:"name"`
+	ID        float64        `json:"id"`
+	Types     []PokemonType  `json:"types"`
+	Abilities PokemonAbility `json:"ability"`
+}
+
 type PokemonType struct {
 	Name string  `json:"type_name"`
 	Slot float64 `json:"slot"`

--- a/pkmn/pokemon_models.go
+++ b/pkmn/pokemon_models.go
@@ -1,17 +1,24 @@
 package pkmn
 
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
 // there is a "past types" field which is game specific
 // add functinoality when looking at a particular game
 type Pokemon struct {
 	Name      string           `json:"name"`
-	ID        float64          `json:"id"`
+	PokedexID float64          `json:"id"`
 	Types     []PokemonType    `json:"types"`
 	Abilities []PokemonAbility `json:"abilities"`
 }
 
+// this represents a pokemon that is "owned" by the user,
 type ActivePokemon struct {
+	UID       string         `json:"uid"` // so even if there are multiple of the same pokemon specific ones can be identified
 	Name      string         `json:"name"`
-	ID        float64        `json:"id"`
+	PokedexID float64        `json:"id"`
 	Types     []PokemonType  `json:"types"`
 	Abilities PokemonAbility `json:"ability"`
 }
@@ -25,4 +32,13 @@ type PokemonAbility struct {
 	Ability   string  `json:"ability_name"`
 	Is_hidden bool    `json:"is_hidden"`
 	Slot      float64 `json:"slot"`
+}
+
+func (ap *ActivePokemon) GeneratePkmnUID() error {
+	bytes := make([]byte, 16)
+	if _, err := rand.Read(bytes); err != nil {
+		return err
+	}
+	ap.UID = hex.EncodeToString(bytes)
+	return nil
 }

--- a/pkmn_errors/pkmn_errors.go
+++ b/pkmn_errors/pkmn_errors.go
@@ -8,6 +8,8 @@ func ErrorHandler(w http.ResponseWriter, r *http.Request, status int, msg string
 		notFoundError(w, r, msg)
 	case http.StatusInternalServerError:
 		internalServerError(w, r, msg)
+	case http.StatusBadRequest:
+		badRequestError(w, r, msg)
 	}
 }
 
@@ -19,4 +21,9 @@ func internalServerError(w http.ResponseWriter, r *http.Request, msg string) {
 func notFoundError(w http.ResponseWriter, r *http.Request, msg string) {
 	w.WriteHeader(http.StatusNotFound)
 	w.Write([]byte("404 Not Found: " + msg))
+}
+
+func badRequestError(w http.ResponseWriter, r *http.Request, msg string) {
+	w.WriteHeader(http.StatusBadRequest)
+	w.Write([]byte("400 Bad Request: " + msg))
 }


### PR DESCRIPTION
Added the ability to store new pokemon in the box or in the active team. Stored pokemon can be moved from one location to the other, be accessed for their information or "released" meaning that they are deleted from the program. The storage locations themselves can also be retrieved with any pokemon present within.